### PR TITLE
Add common CICD resources as a reusable module

### DIFF
--- a/CICD/cd.tf
+++ b/CICD/cd.tf
@@ -1,0 +1,109 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# --------------------------------------------------------------------------------------
+
+module "cd_common_s3_bucket" {
+  source      = "git::https://github.com/wso2/aws-terraform-modules.git//modules/aws/S3-Account?ref=UnitOfWork"
+  project     = var.project
+  environment = var.environment
+  region      = var.region
+  application = var.cd_bucket_name
+  tags        = var.default_tags
+}
+
+module "cd_project_build" {
+  source             = "git::https://github.com/wso2/aws-terraform-modules.git//modules/aws/Code-Build?ref=UnitOfWork"
+  project            = var.project
+  description        = "CD project to build common artifacts for Kubernetes deployment"
+  build_name         = "common-k8s-deployment"
+  codebuild_role_arn = module.cd_codebuild_role.iam_role_arn
+  environment_variables = [
+    {
+      name  = "ECR_REGISTRY_URL"
+      value = local.ecr_registry_url
+    },
+    {
+      name  = "AWS_REGION"
+      value = var.region
+    },
+    {
+      name  = "EKS_CLUSTER_NAME"
+      value = var.cluster_name
+    }
+  ]
+  tags = var.default_tags
+}
+
+// Common artifacts deployment pipeline for CI/CD
+module "common_deployment_pipeline" {
+  source               = "git::https://github.com/wso2/aws-terraform-modules.git//modules/aws/Code-Pipeline?ref=UnitOfWork"
+  pipeline_name        = "common-deployment"
+  project              = var.project
+  pipeline_role_arn    = module.codepipeline_role.iam_role_arn
+  stages               = local.common_deployment_stages
+  artifact_bucket_name = join("-", [var.project, var.cd_bucket_name, var.environment, var.region, "bucket"])
+  tags                 = var.default_tags
+}
+
+module "cd_integration_s3_bucket" {
+  source      = "git::https://github.com/wso2/aws-terraform-modules.git//modules/aws/S3-Account?ref=UnitOfWork"
+  project     = var.project
+  environment = var.environment
+  region      = var.region
+  application = var.integration_bucket_name
+  tags        = var.default_tags
+}
+
+module "integration_project_build" {
+  source             = "git::https://github.com/wso2/aws-terraform-modules.git//modules/aws/Code-Build?ref=UnitOfWork"
+  project            = var.project
+  description        = "CD project to build common artifacts for Kubernetes deployment"
+  build_name         = "integration-k8s-deployment"
+  codebuild_role_arn = module.cd_codebuild_role.iam_role_arn
+  environment_variables = [
+    {
+      name  = "ECR_REGISTRY_URL"
+      value = local.ecr_registry_url
+    },
+    {
+      name  = "AWS_REGION"
+      value = var.region
+    },
+    {
+      name  = "EKS_CLUSTER_NAME"
+      value = var.cluster_name
+    }
+  ]
+  codebuild_source = {
+    type      = "CODEPIPELINE"
+    buildspec = "buildspec_integration.yml"
+  }
+  tags = var.default_tags
+}
+
+// Integration artifacts deployment pipeline for CI/CD
+module "integration_deployment_pipeline" {
+  source               = "git::https://github.com/wso2/aws-terraform-modules.git//modules/aws/Code-Pipeline?ref=UnitOfWork"
+  pipeline_name        = "integration-deployment"
+  project              = var.project
+  pipeline_role_arn    = module.codepipeline_role.iam_role_arn
+  stages               = local.integration_deployment_stages
+  artifact_bucket_name = join("-", [var.project, var.integration_bucket_name, var.environment, var.region, "bucket"])
+  tags                 = var.default_tags
+}

--- a/CICD/ci.tf
+++ b/CICD/ci.tf
@@ -1,0 +1,72 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# --------------------------------------------------------------------------------------
+
+module "docker_build" {
+  source             = "git::https://github.com/wso2/aws-terraform-modules.git//modules/aws/Code-Build?ref=UnitOfWork"
+  description        = "CI project to build Docker image"
+  project            = var.project
+  build_name         = "docker"
+  codebuild_role_arn = module.codebuild_role.iam_role_arn
+  environment_variables = [
+    {
+      name  = "ECR_REGISTRY_URL"
+      value = local.ecr_registry_url
+    }
+  ]
+  tags = var.default_tags
+}
+
+module "buildspec_injector" {
+  source             = "git::https://github.com/wso2/aws-terraform-modules.git//modules/aws/Code-Build?ref=UnitOfWork"
+  description        = "CI project to build Docker image"
+  project            = var.project
+  build_name         = "buildspec_injector"
+  codebuild_role_arn = module.codebuild_role.iam_role_arn
+  environment_variables = [
+    {
+      name  = "GITHUB_TOKEN"
+      value = var.github_personal_access_token
+    }
+  ]
+  codebuild_source = {
+    type      = "CODEPIPELINE"
+    buildspec = file(var.buildspec_injector_path)
+  }
+  tags = var.default_tags
+}
+
+module "ci_s3_bucket" {
+  source      = "git::https://github.com/wso2/aws-terraform-modules.git//modules/aws/S3-Account?ref=UnitOfWork"
+  project     = var.project
+  environment = var.environment
+  region      = var.region
+  application = var.ci_bucket_name
+  tags        = var.default_tags
+}
+
+module "ci_pipeline" {
+  source               = "git::https://github.com/wso2/aws-terraform-modules.git//modules/aws/Code-Pipeline?ref=UnitOfWork"
+  pipeline_name        = "ci"
+  project              = var.project
+  pipeline_role_arn    = module.codepipeline_role.iam_role_arn
+  stages               = local.ci_stages
+  artifact_bucket_name = join("-", [var.project, var.ci_bucket_name, var.environment, var.region, "bucket"])
+  tags                 = var.default_tags
+}

--- a/CICD/iam.tf
+++ b/CICD/iam.tf
@@ -1,0 +1,133 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# --------------------------------------------------------------------------------------
+
+module "codebuild_iam_policy" {
+  source      = "git::https://github.com/wso2/aws-terraform-modules.git//modules/aws/IAM-Policy?ref=UnitOfWork"
+  project     = var.project
+  environment = var.environment
+  region      = var.region
+  tags        = var.default_tags
+  application = "codebuild"
+  policy      = file(var.codebuild_iam_policy_path)
+}
+
+module "codebuild_role" {
+  source      = "git::https://github.com/wso2/aws-terraform-modules.git//modules/aws/IAM-Role?ref=UnitOfWork"
+  project     = var.project
+  environment = var.environment
+  region      = var.region
+  tags        = var.default_tags
+  application = "codebuild"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action = "sts:AssumeRole"
+      Principal = {
+        Service = "codebuild.amazonaws.com"
+      }
+      Effect = "Allow"
+    }]
+  })
+  policy_arns = [module.codebuild_iam_policy.iam_policy_arn]
+}
+
+module "codepipeline_iam_policy" {
+  source      = "git::https://github.com/wso2/aws-terraform-modules.git//modules/aws/IAM-Policy?ref=UnitOfWork"
+  project     = var.project
+  environment = var.environment
+  region      = var.region
+  tags        = var.default_tags
+  application = "s3_management"
+  policy      = file(var.codepipeline_iam_policy_path)
+}
+
+module "codepipeline_role" {
+  source      = "git::https://github.com/wso2/aws-terraform-modules.git//modules/aws/IAM-Role?ref=UnitOfWork"
+  project     = var.project
+  environment = var.environment
+  region      = var.region
+  tags        = var.default_tags
+  application = "codepipeline"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action = "sts:AssumeRole"
+      Principal = {
+        Service = "codepipeline.amazonaws.com"
+      }
+      Effect = "Allow"
+    }]
+  })
+  policy_arns = [module.codepipeline_iam_policy.iam_policy_arn]
+}
+
+module "cd_codebuild_iam_policy" {
+  source      = "git::https://github.com/wso2/aws-terraform-modules.git//modules/aws/IAM-Policy?ref=UnitOfWork"
+  project     = var.project
+  environment = var.environment
+  region      = var.region
+  tags        = var.default_tags
+  application = "cd-codebuild"
+  policy      = file(var.cd_codebuild_iam_policy_path)
+}
+
+module "cd_codebuild_role" {
+  source      = "git::https://github.com/wso2/aws-terraform-modules.git//modules/aws/IAM-Role?ref=UnitOfWork"
+  project     = var.project
+  environment = var.environment
+  region      = var.region
+  tags        = var.default_tags
+  application = "cd-codebuild"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Principal = {
+          Service = "codebuild.amazonaws.com"
+        }
+        Effect = "Allow"
+      },
+      {
+        Effect = "Allow"
+        Principal = {
+          AWS = var.admin_role
+        }
+        Action = "sts:AssumeRole"
+      }
+    ]
+  })
+  policy_arns = [module.cd_codebuild_iam_policy.iam_policy_arn]
+}
+
+module "eks_access_entry" {
+  source           = "git::https://github.com/wso2/aws-terraform-modules.git//modules/aws/EKS-Access-Entry?ref=UnitOfWork"
+  eks_cluster_name = var.cluster_name
+  principal_arn    = module.cd_codebuild_role.iam_role_arn
+  type             = "STANDARD"
+}
+
+module "eks_access_policy" {
+  source           = "git::https://github.com/wso2/aws-terraform-modules.git//modules/aws/EKS-Access-Policy?ref=UnitOfWork"
+  eks_cluster_name = var.cluster_name
+  principal_arn    = module.cd_codebuild_role.iam_role_arn
+  policy_arn       = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy"
+  type             = "cluster"
+}

--- a/CICD/local.tf
+++ b/CICD/local.tf
@@ -1,0 +1,157 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# --------------------------------------------------------------------------------------
+
+locals {
+  ecr_registry_url = "${var.aws_account_id}.dkr.ecr.${var.region}.amazonaws.com"
+
+  ci_stages = [
+    {
+      name = "Source"
+      actions = [
+        {
+          name             = "Source"
+          category         = "Source"
+          owner            = "ThirdParty"
+          provider         = "GitHub"
+          version          = "1"
+          output_artifacts = ["source_output"]
+          configuration = {
+            Owner      = var.github_org_name
+            Repo       = var.ci_project_integration_build_repo_name
+            Branch     = var.devops_ci_project_build_branch
+            OAuthToken = var.github_personal_access_token
+          }
+        }
+      ]
+    },
+    {
+      name = "Prepare"
+      actions = [
+        {
+          name             = "PrepareSource"
+          category         = "Build"
+          owner            = "AWS"
+          provider         = "CodeBuild"
+          version          = "1"
+          input_artifacts  = ["source_output"]
+          output_artifacts = ["prepared_source"]
+          configuration = {
+            ProjectName = module.buildspec_injector.aws_codebuild_project_name
+          }
+        }
+      ]
+    },
+    {
+      name = "Build"
+      actions = [
+        {
+          name             = "Build"
+          category         = "Build"
+          owner            = "AWS"
+          provider         = "CodeBuild"
+          version          = "1"
+          input_artifacts  = ["prepared_source"]
+          output_artifacts = ["build_output"]
+          configuration = {
+            ProjectName = module.docker_build.aws_codebuild_project_name
+          }
+        }
+      ]
+    }
+  ]
+
+  integration_deployment_stages = [
+    {
+      name = "Source"
+      actions = [
+        {
+          name             = "Source"
+          category         = "Source"
+          owner            = "ThirdParty"
+          provider         = "GitHub"
+          version          = "1"
+          output_artifacts = ["source_output"]
+          configuration = {
+            Owner      = var.github_org_name
+            Repo       = var.cd_project_integration_build_repo_name
+            Branch     = var.devops_cd_project_build_branch
+            OAuthToken = var.github_personal_access_token
+          }
+        }
+      ]
+    },
+    {
+      name = "Build"
+      actions = [
+        {
+          name             = "Build"
+          category         = "Build"
+          owner            = "AWS"
+          provider         = "CodeBuild"
+          version          = "1"
+          input_artifacts  = ["source_output"]
+          output_artifacts = ["build_output"]
+          configuration = {
+            ProjectName = module.integration_project_build.aws_codebuild_project_name
+          }
+        }
+      ]
+    }
+  ]
+
+  common_deployment_stages = [
+    {
+      name = "Source"
+      actions = [
+        {
+          name             = "Source"
+          category         = "Source"
+          owner            = "ThirdParty"
+          provider         = "GitHub"
+          version          = "1"
+          output_artifacts = ["source_output"]
+          configuration = {
+            Owner      = var.github_org_name
+            Repo       = var.cd_project_integration_build_repo_name
+            Branch     = var.devops_cd_project_build_branch
+            OAuthToken = var.github_personal_access_token
+          }
+        }
+      ]
+    },
+    {
+      name = "Build"
+      actions = [
+        {
+          name             = "Build"
+          category         = "Build"
+          owner            = "AWS"
+          provider         = "CodeBuild"
+          version          = "1"
+          input_artifacts  = ["source_output"]
+          output_artifacts = ["build_output"]
+          configuration = {
+            ProjectName = module.cd_project_build.aws_codebuild_project_name
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/CICD/variables.tf
+++ b/CICD/variables.tf
@@ -1,0 +1,139 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# --------------------------------------------------------------------------------------
+
+variable "project" {
+  type        = string
+  description = "Project"
+}
+variable "environment" {
+  type        = string
+  description = "Environment"
+}
+variable "region" {
+  type        = string
+  description = "Region"
+}
+variable "application" {
+  type        = string
+  description = "Application"
+}
+variable "default_tags" {
+  type        = map(string)
+  description = "Map of default tags to apply to all resources deployed during Private Cloud deployment."
+}
+
+variable "github_personal_access_token" {
+  type        = string
+  description = "Github Org Personal Access Token"
+}
+
+variable "github_org_name" {
+  description = "Github Org Name"
+  type        = string
+}
+
+variable "ci_project_integration_build_repo_name" {
+  description = "The name of the CI project IS build repo"
+  type        = string
+}
+
+variable "devops_ci_project_build_branch" {
+  description = "The name of the CI project build repo"
+  type        = string
+}
+
+variable "ci_bucket_name" {
+  description = "S3 bucket name for codepipeline"
+  type        = string
+  default     = "test-bucket"
+}
+
+variable "devops_ci_project_integration_build_yml_path" {
+  description = "The path of the CI project IS build yml"
+  type        = string
+  default     = "ci-pipelines/azure-pipeline-001.yml"
+}
+
+variable "cd_project_integration_build_repo_name" {
+  description = "The name of the CI project IS build repo"
+  type        = string
+}
+
+variable "devops_cd_project_build_branch" {
+  description = "The name of the CI project build repo"
+  type        = string
+}
+
+variable "cd_bucket_name" {
+  description = "S3 bucket name for codepipeline for CD"
+  type        = string
+  default     = "test-bucket"
+}
+
+variable "integration_bucket_name" {
+  description = "S3 bucket name for codepipeline for integration"
+  type        = string
+  default     = "test-bucket"
+}
+
+variable "admin_role" {
+  type        = string
+  description = "Admin role ARN to access AWS resources."
+}
+
+variable "enable_ecr_repo_creation" {
+  type        = bool
+  description = "Enable ECR repository creation."
+  default     = true
+}
+
+variable "buildspec_injector_path" {
+  type        = string
+  description = "Path to the buildspec injector file."
+  default     = "buildspec_injector.yml"
+}
+
+variable "codebuild_iam_policy_path" {
+  type        = string
+  description = "Path to the CodeBuild IAM policy file."
+  default     = "resources/codebuild-iam-policy.json"
+}
+
+variable "codepipeline_iam_policy_path" {
+  type        = string
+  description = "Path to the CodePipeline IAM policy file."
+  default     = "resources/codepipeline-iam-policy.json"
+}
+
+variable "cd_codebuild_iam_policy_path" {
+  type        = string
+  description = "Path to the CD CodeBuild IAM policy file."
+  default     = "resources/cd-codebuild-iam-policy.json"
+}
+
+variable "cluster_name" {
+  type        = string
+  description = "EKS cluster name."
+}
+
+variable "aws_account_id" {
+  type        = string
+  description = "AWS account ID."
+}


### PR DESCRIPTION
## Purpose
This pull request introduces the necessary resources for setting up CI/CD pipelines to support various stages of the deployment workflow.

## Goals
Introduce the CICD pipelines as a reusable module.

## Approach
The following pipelines and supporting infrastructure are provisioned:

**Build Pipeline** – Builds Docker images and pushes them to the container registry.
**Common CD Pipeline** – Deploys shared artifacts required for continuous deployment.
**Service-specific CD Pipeline** – Deploys artifacts specific to individual services or environments.
